### PR TITLE
Improve HF integration

### DIFF
--- a/model.py
+++ b/model.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 import torch
 from torch import Tensor, nn
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from modules.layers import (DoubleStreamBlock, EmbedND, LastLayer,
                                  MLPEmbedder, SingleStreamBlock,
                                  timestep_embedding)
@@ -24,7 +26,7 @@ class FluxParams:
     guidance_embed: bool
 
 
-class Flux(nn.Module):
+class Flux(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/feizc/FluxMusic", pipeline_tag="text-to-audio", tags=["text-to-music"], license="apache-2.0"):
     """
     Transformer model for flow matching on sequences.
     """

--- a/sample.py
+++ b/sample.py
@@ -53,11 +53,9 @@ def main(args):
 
     latent_size = (256, 16) 
 
-    model = build_model(args.version).to(device) 
-    local_path = args.ckpt_path
-    state_dict = torch.load(local_path, map_location=lambda storage, loc: storage)
-    model.load_state_dict(state_dict['ema'])
-    model.eval()  # important! 
+    repo_id = f"feizhengcong/FluxMusic-{args.version}"
+    model.from_pretrained(repo_id)
+    model.to(device) 
     diffusion = RF()
 
     # Setup VAE
@@ -112,7 +110,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", type=str, default="small")
     parser.add_argument("--prompt_file", type=str, default='config/example.txt')
-    parser.add_argument("--ckpt_path", type=str, default='musicflow_s.pt')
     parser.add_argument("--audioldm2_model_path", type=str, default='/maindata/data/shared/multimodal/public/dataset_music/audioldm2' )
     parser.add_argument("--seed", type=int, default=2024)
     args = parser.parse_args()


### PR DESCRIPTION
Hi @feizc,

Thanks for this nice work! I see the weights are already on the hub (nice!) but things like download counts don't work.

This PR aims to improve the HF integration:

* automatically load the model using `from_pretrained` (and push it using `push_to_hub`)
* track download numbers for your models (similar to models in the Transformers library)
* have nice model cards on a per-model basis along with appropriate tags (so that people find them when filtering https://huggingface.co/models?pipeline_tag=text-to-audio) 
* perhaps most importantly, leverage `safetensors` for the weights in favor of pickle. 

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from model import Flux

# reload
model = Flux.from_pretrained("feizhengcong/FluxMusic-small")

# optionally, save locally or push to the hub
model.save_pretrained("...")
model.push_to_hub("your-hf-org-or-username/flux-small")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. 

Would you be interested in this integration?

Kind regards,

Niels

## Note

Please don't merge this PR before pushing the model to the hub :)